### PR TITLE
fix: Stack creation now respects configured default branch

### DIFF
--- a/src/stack/manager.rs
+++ b/src/stack/manager.rs
@@ -55,37 +55,31 @@ impl StackManager {
         let stacks_file = config_dir.join("stacks.json");
         let metadata_file = config_dir.join("metadata.json");
 
-        // Determine default base branch - try current branch first, then use configuration
-        let default_base = match repo.get_current_branch() {
-            Ok(branch) => branch,
-            Err(_) => {
-                // Load configuration to get the configured default branch
-                let config_file = config_dir.join("config.json");
-                let settings = Settings::load_from_file(&config_file).unwrap_or_default();
-                let configured_default = &settings.git.default_branch;
+        // Load configuration to get the configured default branch
+        let config_file = config_dir.join("config.json");
+        let settings = Settings::load_from_file(&config_file).unwrap_or_default();
+        let configured_default = &settings.git.default_branch;
 
-                info!("Using configured default branch: {}", configured_default);
+        info!("Using configured default branch: {}", configured_default);
 
-                // Try configured default branch first
-                if repo.branch_exists(configured_default) {
+        // Determine default base branch - use configured default if it exists
+        let default_base = if repo.branch_exists(configured_default) {
+            info!(
+                "Found configured default branch locally: {}",
+                configured_default
+            );
+            configured_default.clone()
+        } else {
+            // Fall back to detecting a suitable branch
+            match repo.detect_main_branch() {
+                Ok(detected) => {
                     info!(
-                        "Found configured default branch locally: {}",
-                        configured_default
+                        "Configured default branch '{}' not found, using detected branch: {}",
+                        configured_default, detected
                     );
-                    configured_default.clone()
-                } else if repo.branch_exists("main") {
-                    info!(
-                        "Configured default branch '{}' not found, falling back to 'main'",
-                        configured_default
-                    );
-                    "main".to_string()
-                } else if repo.branch_exists("master") {
-                    info!(
-                        "Configured default branch '{}' not found, falling back to 'master'",
-                        configured_default
-                    );
-                    "master".to_string()
-                } else {
+                    detected
+                }
+                Err(_) => {
                     // Use configured default even if it doesn't exist yet (might be created later)
                     info!(
                         "Using configured default branch '{}' even though it doesn't exist locally",


### PR DESCRIPTION
## Summary
Fixed stack creation to respect the configured `git.default_branch` instead of using the current Git branch as the default base branch.

## Problem
When creating a new stack with `ca stacks create`, the system was using the current Git branch as the default base branch for the stack. This meant that if you were on branch "standalone-pages" and ran `ca stacks create`, it would use "standalone-pages" as the base branch, even if you had configured `git.default_branch = "develop"`.

This was confusing and unexpected behavior, as users expect their configured default branch to be respected.

## Solution
Changed the logic in `StackManager::new()` to:
1. **Always** load and use the configured `git.default_branch` as the primary choice
2. Only fall back to branch detection if the configured branch doesn't exist locally
3. Use the configured branch even if it doesn't exist yet (it might be created later)

The previous logic that tried the current branch first has been removed entirely.

## Test plan
- [x] All 48 stack-related unit tests pass
- [x] Code builds successfully
- [x] Manual testing confirms the fix works as expected

## Example
Before this fix:
```bash
$ git checkout standalone-pages
$ ca config set git.default_branch "develop"
$ ca stacks create my-feature
# Would use "standalone-pages" as base branch ❌
```

After this fix:
```bash
$ git checkout standalone-pages  
$ ca config set git.default_branch "develop"
$ ca stacks create my-feature
# Uses "develop" as base branch ✅
```

🤖 Generated with [Claude Code](https://claude.ai/code)