### PR TITLE
fix: Remove remaining tracing::info\! calls from push output

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -615,9 +615,7 @@ impl Cli {
                 commands::stack::run(validate_action).await
             }
 
-            Commands::CompletionHelper { action } => {
-                handle_completion_helper(action).await
-            }
+            Commands::CompletionHelper { action } => handle_completion_helper(action).await,
         }
     }
 
@@ -764,7 +762,7 @@ async fn handle_completion_helper(action: CompletionHelperAction) -> Result<()> 
             use crate::git::find_repository_root;
             use crate::stack::StackManager;
             use std::env;
-            
+
             // Try to get stack names, but silently fail if not in a repository
             if let Ok(current_dir) = env::current_dir() {
                 if let Ok(repo_root) = find_repository_root(&current_dir) {
@@ -779,4 +777,3 @@ async fn handle_completion_helper(action: CompletionHelperAction) -> Result<()> 
         }
     }
 }
-

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -218,7 +218,7 @@ impl GitRepository {
             .branch(name, &target_commit, false)
             .map_err(|e| CascadeError::branch(format!("Could not create branch '{name}': {e}")))?;
 
-        tracing::info!("Created branch '{}'", name);
+        // Branch creation logging is handled by the caller for clean output
         Ok(())
     }
 

--- a/src/stack/manager.rs
+++ b/src/stack/manager.rs
@@ -377,7 +377,7 @@ impl StackManager {
         // 🆕 CREATE ACTUAL GIT BRANCH from the specific commit
         // Check if branch already exists
         if self.repo.branch_exists(&branch) {
-            tracing::info!("Branch '{}' already exists, skipping creation", branch);
+            // Branch already exists, skip creation
         } else {
             // Create the branch from the specific commit hash
             self.repo
@@ -391,11 +391,7 @@ impl StackManager {
                     ))
                 })?;
 
-            tracing::info!(
-                "✅ Created Git branch '{}' from commit {}",
-                branch,
-                &commit_hash[..8]
-            );
+            // Branch creation succeeded - logging handled by caller
         }
 
         // Add to stack


### PR DESCRIPTION
Removed INFO log outputs that were bypassing the clean output formatting system during push operations. These logs were showing up as raw "INFO" messages instead of using the proper Output formatting.

Changes:
- Removed tracing::info\! from branch creation in GitRepository
- Removed tracing::info\! logs from stack push operations
- Added comments indicating logging is handled by the caller

This ensures all user-facing output uses the consistent Output formatting system without raw log prefixes.

🤖 Generated with [Claude Code](https://claude.ai/code)